### PR TITLE
add features - correlation coefficients (spearman, pearson)

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,6 +106,11 @@ the output JSON format:
             "num_-1":"number of -1 and -1.0 in the column",
             "num_outlier": "number of outliers n sigma away from mean, default n = 3",
         },
+        "correlation": {
+            "columns": "column names (in order) in the correlation coefficient table",
+            "pearson": "pearson correlation coefficient of this column with others",
+            "spearman": "spearman correlation coefficient of this column with others"
+        },
         "numeric_density": "density of Arabic numbers of the column",
         "contain_numeric": {
             "count": "number of cells which contain numeric character(s)",

--- a/dsbox/datapreprocessing/profiler/data_profile.py
+++ b/dsbox/datapreprocessing/profiler/data_profile.py
@@ -24,12 +24,19 @@ def profile_data(data_path, punctuation_outlier_weight=3,
     ## csv as input ##
     if not isinstance(data_path, pd.DataFrame):
         data = pd.read_csv(data_path, dtype = object)   # all read as str
-    
+        data_for_corr = pd.read_csv(data_path)
+        corr_pearson = data_for_corr.corr()
+        corr_spearman = data_for_corr.corr(method='spearman')
+
     ## data frame as imput ##
     else:
         data = data_path
         isDF = True
-    
+        corr_pearson = data.corr()
+        corr_spearman = data.corr(method='spearman')
+
+    corr_columns = list(corr_pearson.columns)
+
     print "====================have a look on the data: ====================\n"
     print data.head()
 
@@ -42,6 +49,14 @@ def profile_data(data_path, punctuation_outlier_weight=3,
         # dict: map feature name to content
         each_res = defaultdict(lambda: defaultdict())
         
+        if column_name in corr_columns:
+            corr_dict = {}
+            corr_dict["columns"] = corr_columns
+            corr_dict["pearson"] = list(corr_pearson[column_name])
+            corr_dict["spearman"] = list(corr_spearman[column_name])
+
+            each_res["numeric_stats"]["correlation"] = corr_dict
+
         if col.dtype.kind in np.typecodes['AllInteger']+'uMmf':
             each_res["missing"]["num_missing"] = pd.isnull(col).sum()
             each_res["missing"]["num_nonblank"] = col.count()


### PR DESCRIPTION
column_name:{
    numeric_stats:{
        correlation:{
            columns: [column names (in order)]
            spearman: [spearman correlation coef]
            pearson: [pearson correlation coef]
        }
    }
}

1. may looks redundant... (repeated column names)
2. correlation coefficient for for some column pairs may be NaN, e.g. a=[1,1,1,1], b=[1,2,3,4]